### PR TITLE
버그 :: 토큰 만료시 로그인 페이지로 이동

### DIFF
--- a/src/libs/utils/serverApiInstance.ts
+++ b/src/libs/utils/serverApiInstance.ts
@@ -1,6 +1,10 @@
+"use server";
+
 import axios from "axios";
 import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
 const authHost = process.env.NEXT_PUBLIC_API_DOMAIN;
 
 const serverApiInstance = axios.create({
@@ -21,6 +25,17 @@ serverApiInstance.interceptors.request.use(
     return config;
   },
   (error) => Promise.reject(error)
+);
+
+serverApiInstance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      redirect(`${basePath}/auth/login`);
+    }
+
+    return Promise.reject(error);
+  }
 );
 
 export default serverApiInstance;


### PR DESCRIPTION
## Sourcery 요약

버그 수정:
- API로부터 401 에러를 받았을 때 로그인 페이지로 리다이렉트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Redirect to the login page when a 401 error is received from the API.

</details>