### PR TITLE
버그 :: 토큰 만료시 로그인 페이지로 이동

### DIFF
--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -3,7 +3,9 @@ import { cookies } from "next/headers";
 import jwt from "jsonwebtoken";
 import { userUpdate, userDelete } from "@/src/libs/user";
 
-async function GET() {
+const DOMAIN = process.env.NEXT_PUBLIC_DOMAIN;
+
+async function GET(request: NextRequest) {
   try {
     // 토큰 쿠키 가져오기
     const accessToken = cookies().get("AccessToken")?.value;
@@ -23,7 +25,7 @@ async function GET() {
 
     // 액세스 토큰 만료 시간 체크
     if (exp < Date.now() / 1000) {
-      return NextResponse.json({ message: "토큰이 만료되었습니다." }, { status: 401 });
+      return NextResponse.redirect(new URL(`${DOMAIN}/chatforyouio/front`, request.url));
     }
 
     // 세션 토큰 데이터 생성
@@ -33,7 +35,7 @@ async function GET() {
     return NextResponse.json({ message: "로그인에 성공했습니다.", session }, { status: 200 });
   } catch (error) {
     console.error(error);
-    return NextResponse.json({ message: "로그인에 실패했습니다." }, { status: 401 });
+    return NextResponse.redirect(new URL(`${DOMAIN}/chatforyouio/front`, request.url));
   }
 }
 

--- a/src/app/api/signin/route.ts
+++ b/src/app/api/signin/route.ts
@@ -4,6 +4,7 @@ import { signIn } from "@/src/libs/auth";
 import { cookies } from "next/headers";
 
 const JWT_SECRET = process.env.JWT_SECRET || '';
+const DOMAIN = process.env.NEXT_PUBLIC_DOMAIN;
 
 export async function POST(request: NextRequest) {
   try {
@@ -24,7 +25,7 @@ export async function POST(request: NextRequest) {
 
     // 로그인 실패 시
     if (!isSuccess) {
-      return NextResponse.json({ message: "아이디 또는 비밀번호가 잘못되었습니다. 다시 확인해 주세요." }, { status: 401 });
+      return NextResponse.redirect(new URL(`${DOMAIN}/chatforyouio/front`, request.url));
     }
 
     // 사용자 데이터가 존재하지 않을 경우
@@ -70,6 +71,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ message: "로그인 성공", userData }, { status: 200 });
   } catch (error) {
     console.error(error);
-    return NextResponse.json({ message: "로그인에 실패했습니다." }, { status: 401 });
+    return NextResponse.redirect(new URL(`${DOMAIN}/chatforyouio/front`, request.url));
   }
 }

--- a/src/app/api/signout/route.ts
+++ b/src/app/api/signout/route.ts
@@ -1,7 +1,9 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
-export async function POST() {
+const DOMAIN = process.env.NEXT_PUBLIC_DOMAIN;
+
+export async function POST(request: NextRequest) {
   try {
     // AccessToken 쿠키 삭제
     cookies().delete("AccessToken");
@@ -12,9 +14,9 @@ export async function POST() {
     // SessionToken 쿠키 삭제
     cookies().delete("SessionToken");
 
-    return NextResponse.json({ message: "로그아웃에 성공했습니다." }, { status: 200 });
+    return NextResponse.redirect(new URL(`${DOMAIN}/chatforyouio/front`, request.url));
   } catch (error) {
     console.error(error);
-    return NextResponse.json({ message: "로그아웃에 실패했습니다." }, { status: 401 });
+    return NextResponse.redirect(new URL(`${DOMAIN}/chatforyouio/front`, request.url));
   }
 }

--- a/src/libs/utils/serverApiInstance.ts
+++ b/src/libs/utils/serverApiInstance.ts
@@ -1,10 +1,6 @@
-"use server";
-
 import axios from "axios";
 import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
 
-const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
 const authHost = process.env.NEXT_PUBLIC_API_DOMAIN;
 
 const serverApiInstance = axios.create({
@@ -25,17 +21,6 @@ serverApiInstance.interceptors.request.use(
     return config;
   },
   (error) => Promise.reject(error)
-);
-
-serverApiInstance.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      redirect(`${basePath}/auth/login`);
-    }
-
-    return Promise.reject(error);
-  }
 );
 
 export default serverApiInstance;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function middleware(req: NextRequest) {
+export async function middleware(request: NextRequest) {
   const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
-
-  const { pathname, origin } = req.nextUrl;
+  const { pathname, origin } = request.nextUrl;
 
   const isPublicPath = pathname.startsWith("/auth/");
-  const accessToken = req.cookies.get("AccessToken")?.value;
+  const accessToken = request.cookies.get("AccessToken")?.value;
 
   // 인증된 사용자가 인증 페이지에 접근할 경우 홈으로 리다이렉트
   if (accessToken && isPublicPath) {


### PR DESCRIPTION
## Sourcery 요약

버그 수정:
- 액세스 토큰이 만료되거나 인증에 실패할 경우 로그인 페이지로 리디렉션합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Redirect to the login page when the access token expires or authentication fails.

</details>