### PR TITLE
Bug/access token

### DIFF
--- a/src/app/api/signin/route.ts
+++ b/src/app/api/signin/route.ts
@@ -68,9 +68,9 @@ export async function POST(request: NextRequest) {
       expires: new Date(Date.now() + 60 * 60 * 1000), // 1시간
     });
 
-    return NextResponse.json({ message: "로그인 성공", userData }, { status: 200 });
+    return NextResponse.json({ isSuccess: true, message: "로그인 성공", userData }, { status: 200 });
   } catch (error) {
     console.error(error);
-    return NextResponse.redirect(new URL(`${DOMAIN}/chatforyouio/front`, request.url));
+    return NextResponse.json({ isSuccess: false, message: "로그인 실패" }, { status: 400 });
   }
 }

--- a/src/app/api/signout/route.ts
+++ b/src/app/api/signout/route.ts
@@ -1,9 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
-const DOMAIN = process.env.NEXT_PUBLIC_DOMAIN;
-
-export async function POST(request: NextRequest) {
+export async function POST() {
   try {
     // AccessToken 쿠키 삭제
     cookies().delete("AccessToken");

--- a/src/app/api/signout/route.ts
+++ b/src/app/api/signout/route.ts
@@ -14,9 +14,9 @@ export async function POST(request: NextRequest) {
     // SessionToken 쿠키 삭제
     cookies().delete("SessionToken");
 
-    return NextResponse.redirect(new URL(`${DOMAIN}/chatforyouio/front`, request.url));
+    return NextResponse.json({ isSuccess: true });
   } catch (error) {
     console.error(error);
-    return NextResponse.redirect(new URL(`${DOMAIN}/chatforyouio/front`, request.url));
+    return NextResponse.json({ isSuccess: false });
   }
 }

--- a/src/libs/auth.ts
+++ b/src/libs/auth.ts
@@ -130,4 +130,29 @@ async function validate(email: string): Promise<ValidateResponse> {
   }
 }
 
-export { signIn, socialSignIn, logout, validate };
+/**
+ * 토큰 갱신
+ * @returns {Promise<SignInResponse>} 액세스 토큰, 리프레시 토큰 또는 에러 응답
+ */
+async function refreshToken(idx: number, id: string): Promise<SignInResponse> {
+  try {
+    const { headers } = await serverApiInstance.post("/chatforyouio/auth/refresh", { idx, id });
+
+    const accessToken = headers["accesstoken"];
+    const refreshToken = headers["refreshtoken"];
+    
+    if (!accessToken || !refreshToken) {
+      throw new AxiosError("토큰을 가져오는데 실패했습니다.");
+    }
+
+    return {
+      isSuccess: true,
+      accessToken,
+      refreshToken
+    };
+  } catch (error) {
+    return handleAxiosError(error as AxiosError);
+  }
+}
+
+export { signIn, socialSignIn, logout, validate, refreshToken };

--- a/src/libs/auth.ts
+++ b/src/libs/auth.ts
@@ -136,7 +136,7 @@ async function validate(email: string): Promise<ValidateResponse> {
  */
 async function refreshToken(idx: number, id: string): Promise<SignInResponse> {
   try {
-    const { headers } = await serverApiInstance.post("/chatforyouio/auth/refresh", { idx, id });
+    const { headers } = await serverApiInstance.post("/chatforyouio/auth/refresh_token", { idx, id });
 
     const accessToken = headers["accesstoken"];
     const refreshToken = headers["refreshtoken"];

--- a/src/libs/utils/serverApiInstance.ts
+++ b/src/libs/utils/serverApiInstance.ts
@@ -10,12 +10,18 @@ const serverApiInstance = axios.create({
 
 serverApiInstance.interceptors.request.use(
   (config) => {
+    const url = config.url;
+
     const accessToken = cookies().get("AccessToken")?.value;
     const refreshToken = cookies().get("RefreshToken")?.value;
 
     if (accessToken || refreshToken) {
-      config.headers.Authorization = `Bearer ${accessToken}`;
-      config.headers.RefreshToken = `Bearer ${refreshToken}`;
+      if (url === "/chatforyouio/auth/refresh_token") {
+        config.headers.Authorization = `Bearer ${refreshToken}`;
+      } else {
+        config.headers.Authorization = `Bearer ${accessToken}`;
+        config.headers.RefreshToken = `Bearer ${refreshToken}`;
+      }
     }
 
     return config;

--- a/src/libs/utils/serverCommon.ts
+++ b/src/libs/utils/serverCommon.ts
@@ -8,7 +8,7 @@ interface AxiosErrorData {
 }
 
 const handleAxiosError = (error: AxiosError) => {
-  const { code, message} = error.response?.data as AxiosErrorData;
+  const { code, message} = error.response?.data as AxiosErrorData || {};
   return { isSuccess: false, code, message };
 };
 


### PR DESCRIPTION
## Sourcery 요약

액세스 토큰이 만료되었을 때 액세스 토큰 갱신 기능을 구현합니다. 또한, 로그인 및 로그아웃 API를 리디렉션 대신 JSON 응답을 반환하도록 수정합니다.

개선 사항:
- 리프레시 토큰을 사용하여 액세스 토큰 갱신 기능을 구현합니다. 액세스 토큰이 만료되면 서버는 리프레시 토큰을 사용하여 갱신을 시도합니다. 성공하면 새 액세스 토큰과 리프레시 토큰이 쿠키로 설정됩니다.
- 로그인 및 로그아웃 API를 리디렉션 대신 JSON 응답을 반환하도록 수정합니다. 이를 통해 클라이언트가 응답을 처리하고 적절하게 리디렉션할 수 있습니다.
- 리프레시 토큰 API를 호출할 때 서버 API 인스턴스가 인증 헤더에 리프레시 토큰을 포함하도록 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implements access token refresh functionality when the access token expires. Also, modifies sign-in and sign-out APIs to return JSON responses instead of redirecting.

Enhancements:
- Implement access token refresh functionality using refresh tokens. When the access token expires, the server will attempt to refresh it using the refresh token. If successful, the new access token and refresh token are set as cookies.
- Modify sign-in and sign-out APIs to return JSON responses instead of redirecting. This allows the client to handle the response and redirect accordingly.
- Update the server API instance to include the refresh token in the authorization header when calling the refresh token API.

</details>