### PR TITLE
리팩토링 :: 비디오 디바이스 권한 체크

### DIFF
--- a/src/components/openvidu/OpenViduCard.tsx
+++ b/src/components/openvidu/OpenViduCard.tsx
@@ -14,21 +14,29 @@ interface OpenViduCardProps {
 }
 
 export default function OpenViduCard({ chatroom, token }: OpenViduCardProps) {
-  const { publisher, subscribers, initSession, joinSession } = useOpenVidu();
+  const { publisher, subscribers, initSession, joinSession, leaveSession } = useOpenVidu();
   const { user } = useSession();
   const router = useRouter();
 
   useEffect(() => {
     if (!token || !user) return;
 
-    try {
-      initSession();
-      joinSession(token, user.idx);
-    } catch (error) {
-      console.error(error);
-      router.push("/");
-    }
-  }, [token, user, initSession, joinSession, router]);
+    const setup = async () => {
+      try {
+        initSession();
+        await joinSession(token, user.idx);
+      } catch (error) {
+        console.error(error);
+        router.push("/");
+      }
+    };
+
+    setup();
+
+    return () => {
+      leaveSession();
+    };
+  }, [token, user, initSession, joinSession, leaveSession, router]);
   
   return (
     <div className="flex flex-col justify-center items-center gap-4 p-4 md:p-8 bg-white rounded-2xl md:shadow-xl">

--- a/src/components/openvidu/OpenViduDevices.tsx
+++ b/src/components/openvidu/OpenViduDevices.tsx
@@ -21,7 +21,7 @@ export default function OpenViduDevices() {
 
   return (
     <div className="flex gap-2 w-full bg-white">
-      <div className="flex items-center">
+      <div className="flex items-center w-full">
         <button
           type="button"
           onClick={toggleAudio}
@@ -37,12 +37,13 @@ export default function OpenViduDevices() {
           value={selectedAudio}
           onChange={(event) => changeAudioDevice(event.target.value)}
           className="border border-primary p-2 w-full h-12 hover:bg-gray-300 rounded-r-full shadow-md truncate">
+          {audioDevices?.length === 0 && <option className="text-sm" value="">오디오 장치가 없습니다.</option>}
           {audioDevices?.map((device) => (
             <option key={device.deviceId} className="text-sm" value={device.deviceId}>{device.label}</option>
           ))}
         </select>
       </div>
-      <div className="flex items-center">
+      <div className="flex items-center w-full">
         <button
           type="button"
           onClick={toggleVideo}
@@ -58,6 +59,7 @@ export default function OpenViduDevices() {
           value={selectedVideo}
           onChange={(event) => changeVideoDevice(event.target.value)}
           className="border border-primary p-2 w-full h-12 hover:bg-gray-300 rounded-r-full shadow-md truncate">
+          {videoDevices?.length === 0 && <option className="text-sm" value="">비디오 장치가 없습니다.</option>}
           {videoDevices?.map((device) => (
             <option key={device.deviceId} className="text-sm" value={device.deviceId}>{device.label}</option>
           ))}

--- a/src/types/openvidu.d.ts
+++ b/src/types/openvidu.d.ts
@@ -1,3 +1,5 @@
+import { Publisher } from "openvidu-browser";
+
 interface OpenViduContextType {
   ov: OpenVidu | null;
   session: Session | null;
@@ -16,4 +18,6 @@ interface OpenViduContextType {
   initSession: () => Promise<void>;
   joinSession: (token: string, userIdx: number) => Promise<void>;
   leaveSession: () => Promise<void>;
+  initPublisher: () => Promise<Publisher>;
+  replacePublisher: () => void;
 }


### PR DESCRIPTION
## Sourcery 요약

OpenVidu 퍼블리셔 설정 및 장치 전환을 리팩터링하여 권한 오류 및 동적 미디어 장치 변경을 강력하게 처리합니다.

개선 사항:
- 비디오 액세스 오류에 대한 폴백을 사용하여 퍼블리셔 초기화를 `initPublisher` 도우미로 추출
- 미디어 장치를 변경할 때 스트림을 언퍼블리시하고 다시 퍼블리시하는 `replacePublisher` 추가
- `initPublisher`를 사용하고 컴포넌트 언마운트 시 `leaveSession`이 호출되도록 세션 연결 로직을 리팩터링
- `selectedAudio` 및 `selectedVideo`를 업데이트하기 전에 퍼블리셔 교체를 트리거하도록 장치 변경 핸들러 업데이트
- 오디오 또는 비디오 장치를 사용할 수 없는 경우 자리 표시자 옵션을 표시하도록 장치 드롭다운 개선

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor OpenVidu publisher setup and device switching to robustly handle permission errors and dynamic media device changes

Enhancements:
- Extract publisher initialization into an initPublisher helper with fallback for video access errors
- Add replacePublisher to unpublish and republish streams when changing media devices
- Refactor session join logic to use initPublisher and ensure leaveSession is called on component unmount
- Update device change handlers to trigger publisher replacement before updating selectedAudio and selectedVideo
- Enhance device dropdowns to display placeholder options when no audio or video devices are available

</details>