### PR TITLE
리팩토링 :: 디바이스 목록 조회문 수정

### DIFF
--- a/src/components/openvidu/OpenViduCard.tsx
+++ b/src/components/openvidu/OpenViduCard.tsx
@@ -23,7 +23,7 @@ export default function OpenViduCard({ chatroom, token }: OpenViduCardProps) {
 
     const setup = async () => {
       try {
-        initSession();
+        await initSession();
         await joinSession(token, user.idx);
       } catch (error) {
         console.error(error);

--- a/src/components/openvidu/OpenViduDevices.tsx
+++ b/src/components/openvidu/OpenViduDevices.tsx
@@ -19,6 +19,9 @@ export default function OpenViduDevices() {
     isVideoEnabled,
   } = useOpenVidu();
 
+  const filteredAudioDevices = audioDevices?.filter(device => device.deviceId !== '');
+  const filteredVideoDevices = videoDevices?.filter(device => device.deviceId !== '');
+
   return (
     <div className="flex gap-2 w-full bg-white">
       <div className="flex items-center w-full">
@@ -37,8 +40,8 @@ export default function OpenViduDevices() {
           value={selectedAudio}
           onChange={(event) => changeAudioDevice(event.target.value)}
           className="border border-primary p-2 w-full h-12 hover:bg-gray-300 rounded-r-full shadow-md truncate">
-          {audioDevices?.length === 0 && <option className="text-sm" value="">오디오 장치가 없습니다.</option>}
-          {audioDevices?.map((device) => (
+          {filteredAudioDevices?.length === 0 && <option className="text-sm" value="">오디오 장치가 없습니다.</option>}
+          {filteredAudioDevices?.map((device) => (
             <option key={device.deviceId} className="text-sm" value={device.deviceId}>{device.label}</option>
           ))}
         </select>
@@ -59,8 +62,8 @@ export default function OpenViduDevices() {
           value={selectedVideo}
           onChange={(event) => changeVideoDevice(event.target.value)}
           className="border border-primary p-2 w-full h-12 hover:bg-gray-300 rounded-r-full shadow-md truncate">
-          {videoDevices?.length === 0 && <option className="text-sm" value="">비디오 장치가 없습니다.</option>}
-          {videoDevices?.map((device) => (
+          {filteredVideoDevices?.length === 0 && <option className="text-sm" value="">비디오 장치가 없습니다.</option>}
+          {filteredVideoDevices?.map((device) => (
             <option key={device.deviceId} className="text-sm" value={device.deviceId}>{device.label}</option>
           ))}
         </select>

--- a/src/types/openvidu.d.ts
+++ b/src/types/openvidu.d.ts
@@ -1,12 +1,12 @@
-import { Publisher } from "openvidu-browser";
+import { Device, Publisher } from "openvidu-browser";
 
 interface OpenViduContextType {
   ov: OpenVidu | null;
   session: Session | null;
   publisher: Publisher | null;
   subscribers: Subscriber[];
-  audioDevices: MediaDeviceInfo[];
-  videoDevices: MediaDeviceInfo[];
+  audioDevices: Device[];
+  videoDevices: Device[];
   selectedAudio: string | undefined;
   selectedVideo: string | undefined;
   isAudioEnabled: boolean;


### PR DESCRIPTION
디바이스 목록 조회문 Openvidu 흐름으로 통합되도록 수정

## Sourcery 요약

장치 열거 방식을 리팩토링하여 `navigator.mediaDevices.enumerateDevices()`를 직접 호출하는 대신 `getUserMedia`를 요청한 후 OpenViduBrowser의 `getDevices()`를 사용하도록 하여 OpenVidu 흐름과 통합합니다.

개선 사항:
- 오디오/비디오 장치 검색 방식을 `getUserMedia`를 요청한 후 OpenViduBrowser의 `getDevices()`를 사용하도록 변경
- 컨텍스트 상태 유형을 `MediaDeviceInfo`에서 OpenVidu Device로 업데이트
- 장치 접근 실패에 대한 오류 처리 추가
- effect 훅 의존성을 `ov.current`로 조정

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor device enumeration to integrate with the OpenVidu flow by replacing direct navigator.mediaDevices.enumerateDevices() calls with OpenViduBrowser's getDevices() after requesting getUserMedia.

Enhancements:
- Switch audio/video device retrieval to OpenViduBrowser's getDevices() after requesting getUserMedia
- Update context state types from MediaDeviceInfo to OpenVidu Device
- Add error handling for device access failure
- Adjust effect hook dependency to ov.current

</details>