### PR TITLE
리팩토링 :: 디바이스 목록 조회문 수정

### DIFF
--- a/src/components/openvidu/OpenViduCard.tsx
+++ b/src/components/openvidu/OpenViduCard.tsx
@@ -7,6 +7,7 @@ import OpenViduHeader from "@/src/components/openvidu/OpenViduHeader";
 import OpenViduStreamList from "@/src/components/openvidu/OpenViduStreamList";
 import { useOpenVidu } from "@/src/contexts/OpenViduContext";
 import { useSession } from "@/src/contexts/SessionContext";
+import { StreamManager } from "openvidu-browser";
 
 interface OpenViduCardProps {
   chatroom: Chatroom;
@@ -22,7 +23,6 @@ export default function OpenViduCard({ chatroom, token }: OpenViduCardProps) {
     if (!token || !user) return;
 
     const setup = async () => {
-      console.log("OpenViduCard: Setting up OpenVidu session...");
       try {
         await initSession();
         await joinSession(token, user.idx);
@@ -39,6 +39,18 @@ export default function OpenViduCard({ chatroom, token }: OpenViduCardProps) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token, user]);
+
+  const streamManagers: StreamManager[] = publisher ? [publisher, ...subscribers] : subscribers;
+
+  if (streamManagers.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center gap-4 p-4 md:p-8 bg-white rounded-2xl md:shadow-xl">
+        <OpenViduDevices />
+        <OpenViduHeader chatroom={chatroom} />
+        <p className="text-gray-500">현재 참여자가 없습니다.</p>
+      </div>
+    );
+  }
   
   return (
     <div className="flex flex-col justify-center items-center gap-4 p-4 md:p-8 bg-white rounded-2xl md:shadow-xl">

--- a/src/components/openvidu/OpenViduStream.tsx
+++ b/src/components/openvidu/OpenViduStream.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { StreamManager } from 'openvidu-browser';
-import IconLoader from "@/public/images/icons/loader.svg";
+import IconVideoOff from "@/public/images/icons/video-off.svg";
 
 interface SessionProps {
 	streamManager?: StreamManager;
@@ -16,10 +16,10 @@ export default function OpenViduStream({ streamManager }: SessionProps) {
 		}
 	}, [streamManager]);
 
-  if (!streamManager) {
+  if (!streamManager?.stream.videoActive) {
     return (
       <div className="flex justify-center items-center w-full aspect-video bg-gray-200 rounded-2xl">
-        <IconLoader className="w-12 h-12 animate-spin" />
+        <IconVideoOff className="w-12 h-12" />
       </div>
     );
   }

--- a/src/contexts/OpenViduContext.tsx
+++ b/src/contexts/OpenViduContext.tsx
@@ -25,10 +25,10 @@ export default function OpenViduProvider({ children }: { children: ReactNode }) 
   
     try {
       return await ov.current.initPublisherAsync(undefined, {
-        audioSource: selectedAudio,
-        videoSource: selectedVideo,
-        publishAudio: selectedAudio ? true : false,
-        publishVideo: selectedVideo ? true : false,
+        audioSource: undefined,
+        videoSource: undefined,
+        publishAudio: true,
+        publishVideo: true,
         resolution: "640x480",
         frameRate: 30,
         insertMode: "APPEND",
@@ -38,7 +38,7 @@ export default function OpenViduProvider({ children }: { children: ReactNode }) 
       console.warn("장치 접근에 문제가 발생했습니다. 기본 퍼블리셔를 사용합니다.", error);
       
       return await ov.current.initPublisherAsync(undefined, {
-        audioSource: selectedAudio ?? undefined,
+        audioSource: undefined,
         videoSource: false,
         publishAudio: true,
         publishVideo: false,
@@ -48,7 +48,7 @@ export default function OpenViduProvider({ children }: { children: ReactNode }) 
         mirror: false,
       });
     }
-  }, [selectedAudio, selectedVideo]);
+  }, []);
 
   /**
    * OpenVidu 퍼블리셔 교체


### PR DESCRIPTION
디바이스 목록 조회문 수정

## Sourcery 요약

OpenVidu 장치 초기화 및 참여자 목록 렌더링 리팩토링

개선 사항:
- OpenViduCard에 활성 스트림 관리자가 없을 때 장치 선택 UI 및 참여자 없음 메시지 표시
- 게시자 및 구독자 스트림을 통합 목록으로 결합하여 렌더링
- 항상 기본 오디오/비디오 소스로 게시자를 초기화하고 동적 소스 선택 제거
- 불필요한 게시자 재초기화를 방지하기 위해 선택한 장치에 대한 useEffect 종속성 제거
- 디버그 콘솔 로그 정리 및 openvidu-browser에서 StreamManager 유형 가져오기

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor OpenVidu device initialization and participant list rendering

Enhancements:
- Show device selection UI and no-participant message when there are no active stream managers in OpenViduCard
- Combine publisher and subscriber streams into a unified list for rendering
- Always initialize the publisher with default audio/video sources and remove dynamic source selection
- Remove useEffect dependencies on selected devices to prevent redundant publisher reinitialization
- Clean up debug console logs and import the StreamManager type from openvidu-browser

</details>